### PR TITLE
Updates the plugin to work with IntelliJ Platform 2024.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ group = providers.gradleProperty("pluginGroup").get()
 version = providers.gradleProperty("pluginVersion").get()
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(21)
 }
 
 // Configure project's dependencies

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,13 +4,13 @@
 pluginGroup = net.bjonnh.intellij.filepermissionsplugin
 pluginName = File Permissions
 pluginRepositoryUrl = https://github.com/bjonnh/FilePermissionsPlugin
-pluginVersion = 0.3.0
-pluginSinceBuild = 223
-pluginUntilBuild = 251.*
+pluginVersion = 0.3.1
+pluginSinceBuild = 242
+pluginUntilBuild = 252.*
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType = IC
-platformVersion = 2023.3.8
+platformVersion = 2024.2
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
@@ -18,7 +18,7 @@ platformPlugins =
 platformBundledPlugins =
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
-gradleVersion = 8.10.2
+gradleVersion = 8.13
 
 # Opt-out flag for bundling Kotlin standard library -> https://jb.gg/intellij-platform-kotlin-stdlib
 kotlin.stdlib.default.dependency = false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,16 +1,18 @@
 [versions]
 # libraries
 junit = "4.13.2"
+opentest4j = "1.3.0"
 
 # plugins
 changelog = "2.2.1"
-intelliJPlatform = "2.1.0"
-kotlin = "1.9.25"
-kover = "0.8.3"
-qodana = "2024.2.3"
+intelliJPlatform = "2.5.0"
+kotlin = "2.1.20"
+kover = "0.9.1"
+qodana = "2024.3.4"
 
 [libraries]
 junit = { group = "junit", name = "junit", version.ref = "junit" }
+opentest4j = { group = "org.opentest4j", name = "opentest4j", version.ref = "opentest4j" }
 
 [plugins]
 changelog = { id = "org.jetbrains.changelog", version.ref = "changelog" }

--- a/src/main/kotlin/net/bjonnh/intellij/filepermissionsplugin/actions/ChangePermissionsAction.kt
+++ b/src/main/kotlin/net/bjonnh/intellij/filepermissionsplugin/actions/ChangePermissionsAction.kt
@@ -1,5 +1,6 @@
 package net.bjonnh.intellij.filepermissionsplugin.actions
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
@@ -53,4 +54,10 @@ class ChangePermissionsAction : AnAction() {
             e.presentation.isEnabledAndVisible = false
         }
     }
+
+    /**
+     * Specifies that this action update will be executed on the background
+     * thread.
+     */
+    override fun getActionUpdateThread() = ActionUpdateThread.BGT
 }

--- a/src/main/kotlin/net/bjonnh/intellij/filepermissionsplugin/actions/MakeExecutableAction.kt
+++ b/src/main/kotlin/net/bjonnh/intellij/filepermissionsplugin/actions/MakeExecutableAction.kt
@@ -6,6 +6,7 @@
 
 package net.bjonnh.intellij.filepermissionsplugin.actions
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
@@ -66,4 +67,10 @@ class MakeExecutableAction : AnAction() {
     } catch (ex: IOException) {
         false
     }
+
+    /**
+     * Specifies that this action update will be executed on the background
+     * thread.
+     */
+    override fun getActionUpdateThread() = ActionUpdateThread.BGT
 }


### PR DESCRIPTION
The plugin could be installed in IDEA 2025.1, but did not show the expected entries in menu `File > File Properties`.

This PR updates the dependencies version, and was successfully tested with platform version 2024.2 and 2025.1.

The information was mainly gathered from:

https://github.com/JetBrains/intellij-platform-plugin-template
https://plugins.jetbrains.com/docs/intellij/action-system.html